### PR TITLE
fix(demo3): draco library files can not be found

### DIFF
--- a/demo3/script.js
+++ b/demo3/script.js
@@ -19,7 +19,7 @@ canvasParent.appendChild(renderer.domElement)
 // Initialize loaders
 const loader = new GLTFLoader()
 const dracoLoader = new DRACOLoader()
-dracoLoader.setDecoderPath('https://unpkg.com/three/examples/js/libs/draco/')
+dracoLoader.setDecoderPath('https://unpkg.com/three@0.129.0/examples/js/libs/draco/')
 loader.setDRACOLoader(dracoLoader)
 
 // Initialize the CameraRig 


### PR DESCRIPTION
### Bug Description
https://nytimes.github.io/rd-mobile-pg-demos/demo3/ currently could not render 3D model due to 
- https://unpkg.com/three@0.149.0/examples/js/libs/draco/draco_wasm_wrapper.js
- https://unpkg.com/three@0.149.0/examples/js/libs/draco/draco_decoder.wasm 

404 not found.

### Code Change
Update `demo3/script.js` to specify the Threejs version @0.129.0 to make sure draco library files existed.

